### PR TITLE
Feature/response future

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ async fn main() {
     ccr.add_avp(avp!(415, None, M, Unsigned32::new(1000)));
 
     // Send the CCR message to the server and wait for a response
-    let cca = client.send_message(ccr).await.unwrap();
+    let response = client.send_message(ccr).await.unwrap();
+    let cca = response.await.unwrap();
     println!("Received response: {}", cca);
 }
 ```

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -64,7 +64,8 @@ async fn send_cer(client: &mut DiameterClient) {
     cer.add_avp(avp!(266, None, M, Unsigned32::new(35838)));
     cer.add_avp(avp!(269, None, M, UTF8String::new("diameter-rs")));
 
-    let cea = client.send_message(cer).await.unwrap();
+    let resp = client.send_message(cer).await.unwrap();
+    let cea = resp.await.unwrap();
     log::info!("Received rseponse: {}", cea);
 }
 
@@ -89,6 +90,7 @@ async fn send_ccr(client: &mut DiameterClient) {
         Address::new(IPv4(Ipv4Addr::new(127, 0, 0, 1)))
     ));
 
-    let cca = client.send_message(ccr).await.unwrap();
+    let resp = client.send_message(ccr).await.unwrap();
+    let cca = resp.await.unwrap();
     log::info!("Received rseponse: {}", cca);
 }

--- a/examples/load_generator.rs
+++ b/examples/load_generator.rs
@@ -114,7 +114,8 @@ async fn send_cer(client: &mut DiameterClient) {
     cer.add_avp(avp!(266, None, M, Unsigned32::new(35838)));
     cer.add_avp(avp!(269, None, M, UTF8String::new("diameter-rs")));
 
-    let _cea = client.send_message(cer).await.unwrap();
+    let response = client.send_message(cer).await.unwrap();
+    let _cea = response.await.unwrap();
 }
 
 async fn send_ccr_i(client: &mut DiameterClient, session_id: &str) -> JoinHandle<String> {
@@ -138,7 +139,7 @@ async fn send_ccr_i(client: &mut DiameterClient, session_id: &str) -> JoinHandle
         Address::new(IPv4(Ipv4Addr::new(127, 0, 0, 1)))
     ));
 
-    let mut request = client.request(ccr).await.unwrap();
+    let response = client.send_message(ccr).await.unwrap();
     log::info!(
         "CCR-I  Request sent id: {:>2} session_id: {}",
         seq_num,
@@ -146,8 +147,7 @@ async fn send_ccr_i(client: &mut DiameterClient, session_id: &str) -> JoinHandle
     );
 
     let handle = task::spawn_local(async move {
-        let _ = request.send().await.unwrap();
-        let cca = request.response().await.unwrap();
+        let cca = response.await.unwrap();
         let seq_num = cca.get_hop_by_hop_id();
         let session_id = cca.get_avp(263).unwrap().get_utf8string().unwrap();
         log::info!(
@@ -182,7 +182,7 @@ async fn send_ccr_t(client: &mut DiameterClient, session_id: &str) -> JoinHandle
         Address::new(IPv4(Ipv4Addr::new(127, 0, 0, 1)))
     ));
 
-    let mut request = client.request(ccr).await.unwrap();
+    let response = client.send_message(ccr).await.unwrap();
     log::info!(
         "CCR-T  Request sent id: {:>2} session_id: {}",
         seq_num,
@@ -190,8 +190,7 @@ async fn send_ccr_t(client: &mut DiameterClient, session_id: &str) -> JoinHandle
     );
 
     let handle = task::spawn_local(async move {
-        let _ = request.send().await.unwrap();
-        let cca = request.response().await.unwrap();
+        let cca = response.await.unwrap();
         let seq_num = cca.get_hop_by_hop_id();
         let session_id = cca.get_avp(263).unwrap().get_utf8string().unwrap();
         log::info!(

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -38,7 +38,7 @@ async fn main() {
                 record.args()
             )
         })
-        .filter(None, log::LevelFilter::Info)
+        .filter(None, log::LevelFilter::Warn)
         .init();
 
     // Load dictionary

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -38,7 +38,7 @@ async fn main() {
                 record.args()
             )
         })
-        .filter(None, log::LevelFilter::Warn)
+        .filter(None, log::LevelFilter::Info)
         .init();
 
     // Load dictionary

--- a/src/transport/client.rs
+++ b/src/transport/client.rs
@@ -171,15 +171,14 @@ impl DiameterClient {
         Ok(())
     }
 
-    /// Sends a Diameter message and waits for the response.
-    ///
-    /// This is a convenience method that combines sending a request and waiting for its response.
+    /// Sends a Diameter message and returns a future for receiving the response.
     ///
     /// Args:
-    ///     req: The Diameter message to send.
+    ///   req: The Diameter message to send.
+    ///   Returns:
+    ///   A `ResponseFuture` for receiving the response from the server.
+    ///   The future will resolve to a `DiameterMessage` containing the response.
     ///
-    /// Returns:
-    ///    A `ResponseFuture` that resolves to the response message.
     pub async fn send_message(&mut self, req: DiameterMessage) -> Result<ResponseFuture> {
         if let Some(writer) = &self.writer {
             let (tx, rx) = oneshot::channel();

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -145,7 +145,9 @@ mod tests {
         ccr.add_avp(avp!(263, None, M, UTF8String::new("ses;12345888")));
         ccr.add_avp(avp!(416, None, M, Enumerated::new(1)));
         ccr.add_avp(avp!(415, None, M, Unsigned32::new(1000)));
-        let cca = client.send_message(ccr).await.unwrap();
+        // let cca = client.send_message(ccr).await.unwrap();
+        let response = client.send_message_async(ccr).await.unwrap();
+        let cca = response.await.unwrap();
 
         println!("Response: {}", cca);
 
@@ -171,17 +173,27 @@ mod tests {
             ccr.add_avp(avp!(263, None, M, UTF8String::new("ses;12345888")));
             ccr.add_avp(avp!(416, None, M, Enumerated::new(1)));
             ccr.add_avp(avp!(415, None, M, Unsigned64::new(1000)));
-            let mut request = client.request(ccr).await.unwrap();
+            let response = client.send_message_async(ccr).await.unwrap();
             let handle = tokio::spawn(async move {
-                let _ = request.send().await.unwrap();
-                let cca = request.response().await.unwrap();
-
+                let cca = response.await.unwrap();
                 println!("Response: {}", cca);
 
                 // Assert Result-Code
                 let result_code = &cca.get_avp(268).unwrap();
                 assert_eq!(result_code.get_unsigned32().unwrap(), 2001);
             });
+
+            // let mut request = client.request(ccr).await.unwrap();
+            // let handle = tokio::spawn(async move {
+            //     let _ = request.send().await.unwrap();
+            //     let cca = request.response().await.unwrap();
+            //
+            //     println!("Response: {}", cca);
+            //
+            //     // Assert Result-Code
+            //     let result_code = &cca.get_avp(268).unwrap();
+            //     assert_eq!(result_code.get_unsigned32().unwrap(), 2001);
+            // });
             handles.push(handle);
         }
 

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -146,7 +146,7 @@ mod tests {
         ccr.add_avp(avp!(416, None, M, Enumerated::new(1)));
         ccr.add_avp(avp!(415, None, M, Unsigned32::new(1000)));
         // let cca = client.send_message(ccr).await.unwrap();
-        let response = client.send_message_async(ccr).await.unwrap();
+        let response = client.send_message(ccr).await.unwrap();
         let cca = response.await.unwrap();
 
         println!("Response: {}", cca);
@@ -173,7 +173,7 @@ mod tests {
             ccr.add_avp(avp!(263, None, M, UTF8String::new("ses;12345888")));
             ccr.add_avp(avp!(416, None, M, Enumerated::new(1)));
             ccr.add_avp(avp!(415, None, M, Unsigned64::new(1000)));
-            let response = client.send_message_async(ccr).await.unwrap();
+            let response = client.send_message(ccr).await.unwrap();
             let handle = tokio::spawn(async move {
                 let cca = response.await.unwrap();
                 println!("Response: {}", cca);

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -183,17 +183,6 @@ mod tests {
                 assert_eq!(result_code.get_unsigned32().unwrap(), 2001);
             });
 
-            // let mut request = client.request(ccr).await.unwrap();
-            // let handle = tokio::spawn(async move {
-            //     let _ = request.send().await.unwrap();
-            //     let cca = request.response().await.unwrap();
-            //
-            //     println!("Response: {}", cca);
-            //
-            //     // Assert Result-Code
-            //     let result_code = &cca.get_avp(268).unwrap();
-            //     assert_eq!(result_code.get_unsigned32().unwrap(), 2001);
-            // });
             handles.push(handle);
         }
 


### PR DESCRIPTION
* `client.send_message()` now return `Result<ResponseFuture` instead of `Result<DiameterMessage`