### PR TITLE
fix: add correct padding to avps

### DIFF
--- a/src/avp/group.rs
+++ b/src/avp/group.rs
@@ -65,10 +65,7 @@ impl Grouped {
     }
 
     pub fn length(&self) -> u32 {
-        self.avps
-            .iter()
-            .map(|avp| avp.get_length() + avp.get_padding() as u32)
-            .sum()
+        self.avps.iter().map(|avp| avp.get_length()).sum()
     }
 
     pub fn fmt(&self, f: &mut std::fmt::Formatter<'_>, depth: usize) -> std::fmt::Result {

--- a/src/avp/mod.rs
+++ b/src/avp/mod.rs
@@ -377,23 +377,25 @@ impl Avp {
         dict: Arc<Dictionary>,
     ) -> Avp {
         let header_length = if vendor_id.is_some() { 12 } else { 8 };
-        let padding = Avp::pad_to_32_bits(value.length());
+        let unpadded_len = header_length + value.length();
+        let padding = Avp::pad_to_32_bits(unpadded_len);
+
         let header = AvpHeader {
             code,
             flags: AvpFlags {
-                vendor: if vendor_id.is_some() { true } else { false },
+                vendor: vendor_id.is_some(),
                 mandatory: (flags & flags::M) != 0,
                 private: (flags & flags::P) != 0,
             },
-            length: header_length + value.length(),
+            length: unpadded_len + padding as u32,
             vendor_id,
         };
-        return Avp {
+        Avp {
             header,
             value,
             padding,
             dict,
-        };
+        }
     }
 
     pub fn from_name(avp_name: &str, value: AvpValue, dict: Arc<Dictionary>) -> Result<Avp> {
@@ -778,5 +780,39 @@ mod tests {
         assert_eq!(avp.get_flags().vendor, false);
         assert_eq!(avp.get_vendor_id(), None);
         assert_eq!(avp.get_utf8string().unwrap().value(), "session-id");
+    }
+
+    #[test]
+    fn test_avp_encode_writes_correct_padded_length_in_header() {
+        let dict = Dictionary::new(&[&dictionary::DEFAULT_DICT_XML]);
+        let dict = Arc::new(dict);
+
+        let avp = Avp::new(
+            264, // Origin-Host
+            None,
+            flags::M,
+            UTF8String::new("a").into(),
+            Arc::clone(&dict),
+        );
+
+        let mut buffer = Vec::new();
+        avp.encode_to(&mut buffer).unwrap();
+
+        let length_from_buffer = u32::from_be_bytes([0, buffer[5], buffer[6], buffer[7]]);
+        assert_eq!(
+            length_from_buffer, 12,
+            "The length field in the AVP header bytes must be the padded length (12)"
+        );
+
+        assert_eq!(
+            buffer.len(),
+            12,
+            "The total size of the encoded buffer should be 12 bytes"
+        );
+        assert_eq!(
+            &buffer[9..],
+            &[0x00, 0x00, 0x00],
+            "The last 3 bytes should be null padding"
+        );
     }
 }

--- a/src/diameter.rs
+++ b/src/diameter.rs
@@ -143,7 +143,7 @@ impl DiameterMessage {
 
     /// Adds an AVP to the message.
     pub fn add(&mut self, avp: Avp) {
-        self.header.length += avp.get_length() + avp.get_padding() as u32;
+        self.header.length += avp.get_length();
         self.avps.push(avp);
     }
 


### PR DESCRIPTION
Hello, 

I found an issue when the padding was of then having a `UTF8String` with value like `a`. I updated places where it was needed and added a test to verify changes are working.